### PR TITLE
Build the legacy macOS asset in CI and route its updates separately

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ name: Release
 #   warewoolf_<version>_arm64.deb
 #   warewoolf_<version>_MacOS_Intel.dmg
 #   warewoolf_<version>_MacOS_AppleSilicon.dmg
+#   warewoolf_<version>_MacOS_Legacy.dmg
 #   warewoolf_<version>_Windows_x64.zip
 #
 # The amd64/arm64/Windows_x64 substrings are load-bearing: the in-app updater
@@ -16,6 +17,17 @@ name: Release
 # build is deliberately named "AppleSilicon" rather than "arm64" so it can't
 # collide with that arm64 substring match (which today is Linux-only, but
 # isn't guarded by platform) and get offered to Linux ARM users or vice versa.
+#
+# MacOS_Legacy is the same source packaged against a pinned Electron 32, the
+# last line that runs on macOS 10.15 Catalina. Mainline Electron 44 needs
+# macOS 13 Ventura, so this asset is what every mac between Catalina and 12
+# Monterey updates along. Its name shares no substring with MacOS_Intel for
+# exactly the reason AppleSilicon avoids arm64: the updater's match is a
+# find() over includes(), so an overlapping name would be handed out on
+# whatever order the GitHub API returned the assets in. Nothing here needs to
+# run on an old mac - electron-forge only downloads a prebuilt Electron for
+# the target and copies the app in, and this project has no native modules -
+# so the minimum-OS floor comes from the pinned Electron, not the runner.
 
 on:
   push:
@@ -105,6 +117,9 @@ jobs:
             label: MacOS_Intel
           - arch: arm64
             label: MacOS_AppleSilicon
+          - arch: x64
+            label: MacOS_Legacy
+            electron: ^32.3.3
     steps:
       - uses: actions/checkout@v4
         with:
@@ -113,8 +128,33 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      # Swapped in after npm ci rather than pinned in package.json, so the legacy
+      # build stays byte-for-byte the same source as the mainline one and there is
+      # no second branch or lockfile to keep in step. --no-save leaves both files
+      # untouched. Safe to do without a rebuild step because the project has no
+      # native modules to relink against a different ABI.
+      - name: Pin Electron for the legacy macOS build
+        if: matrix.electron
+        run: npm install --no-save "electron@${{ matrix.electron }}"
       - run: npm run build
       - run: npx electron-forge package --platform=darwin --arch=${{ matrix.arch }}
+      # Checks the built artifact rather than trusting the pin above, the same way
+      # the Linux job checks the deb's compression instead of trusting package.json.
+      # Electron 32 stamps 10.15; every line from 33 on stamps 11 or higher, so a
+      # silently un-pinned build fails here instead of shipping as a legacy asset
+      # that will not launch on any of the machines it is named for.
+      - name: Verify the legacy build still targets macOS 10.x
+        if: matrix.electron
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP_PATH=$(find out -maxdepth 2 -name "*.app" -print -quit)
+          MIN=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$APP_PATH/Contents/Info.plist")
+          echo "$APP_PATH targets macOS $MIN"
+          case "$MIN" in
+            10.*) ;;
+            *) echo "::error::Legacy build targets macOS $MIN, not 10.x - the Electron pin did not take"; exit 1 ;;
+          esac
       - name: Build dmg with hdiutil
         shell: bash
         # @electron-forge/maker-dmg pulls in the unmaintained `appdmg` package
@@ -136,7 +176,7 @@ jobs:
             "out/make/warewoolf_${{ needs.check-version.outputs.version }}_${{ matrix.label }}.dmg"
       - uses: actions/upload-artifact@v4
         with:
-          name: release-asset-macos-${{ matrix.arch }}
+          name: release-asset-macos-${{ matrix.label }}
           path: out/make/warewoolf_*_${{ matrix.label }}.dmg
           if-no-files-found: error
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ For a more in-depth overview of WareWoolf, please see [the Wiki](https://github.
 
 Binaries of the current release for Windows, MacOS, Debian AMD64, and Debian ARM64 (Raspberry Pi) are available in the [releases page](https://github.com/brsloan/warewoolf/releases).
 
+> [!NOTE]
+> **On an older Mac?** The main MacOS builds are packaged against Electron 44, which needs macOS 13 "Ventura" or newer. If you are on macOS 10.15 "Catalina" through 12 "Monterey" — as many of the older laptops people turn into writerdecks are — download `warewoolf_<version>_MacOS_Legacy.dmg` instead. It is the same WareWoolf, built from the same source, packaged against Electron 32: the last release line that runs on those systems. It is an Intel build, so on Apple Silicon it runs under Rosetta. Electron 32 no longer receives Chromium security updates, so take a mainline build instead if your Mac can run one.
+
 > [!WARNING]
 > The Wi-Fi Manager uses nmcli/Network Manager, which Raspberry Pi OS does not have installed/enabled by default. You will have to install network-manager and enable it in raspi-config for this function to work. You may need to update raspi-config to be able to enable Network-Manager.
 
@@ -61,6 +64,7 @@ This app was built using Electron Forge. To run it from source...
 * You must first have [Node.js](https://nodejs.dev/en/learn/how-to-install-nodejs/) installed.
 * Run "npm install" in the WareWoolf source code directory to install the dependencies using the Node Package Manager.
 * Then you can simply use command "npm start" to run the program.
+* **Building on an older Mac.** Two pins in package.json exist for this and are deliberate. `esbuild` is held at 0.23.x because 0.24.0 is built with Go 1.23, which dropped macOS 10.15 — anything newer fails to install on Catalina with a `dyld: Symbol not found` error. Node 20 is the newest release line that runs on Catalina at all, and it is also what Electron 32 bundles, so tests there run on roughly the runtime the app ships with. To run or package the legacy Mac build locally, use "npm run use:legacy-electron" after "npm install"; it swaps in Electron 32 without touching package.json or the lockfile, and "npm ci" puts the mainline Electron back. You do not need any of this to *release* the legacy build — CI produces that asset on every tagged release, on an ordinary macOS runner, since electron-forge only downloads a prebuilt Electron for the target and copies the app into it.
 * To make a binary, "npm run make". See the [Electron Forge documentation](https://www.electronforge.io/) for instructions on how to alter the package.json file for making binaries for different systems, but basically in the "makers" property of the "forge" object in the package.json file, there is an array of different makers for producing different binaries. The "@electron-forge/maker-squirrel" is for producing a Windows binary, the maker-deb for Linux, and the maker-dmg for MacOS. To produce them, run "npm run make" and it should use the appropriate one for your system. You will find the binary in the "out" folder.  
 
 ## Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "warewoolf",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "warewoolf",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^6.0.1",
@@ -25,7 +25,7 @@
         "@electron-forge/maker-squirrel": "^7.11.2",
         "@electron-forge/maker-zip": "^7.11.2",
         "electron": "^44.2.0",
-        "esbuild": "^0.28.2",
+        "esbuild": "^0.23.1",
         "jsdom": "^29.1.1"
       }
     },
@@ -997,9 +997,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
-      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1014,9 +1014,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
-      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
       "cpu": [
         "arm"
       ],
@@ -1031,9 +1031,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
-      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
       "cpu": [
         "arm64"
       ],
@@ -1048,9 +1048,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
-      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
       "cpu": [
         "x64"
       ],
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
-      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1082,9 +1082,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
-      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
       "cpu": [
         "x64"
       ],
@@ -1099,9 +1099,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
-      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
       "cpu": [
         "arm64"
       ],
@@ -1116,9 +1116,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
-      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
       "cpu": [
         "x64"
       ],
@@ -1133,9 +1133,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
-      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
       "cpu": [
         "arm"
       ],
@@ -1150,9 +1150,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
-      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
       "cpu": [
         "arm64"
       ],
@@ -1167,9 +1167,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
-      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
       "cpu": [
         "ia32"
       ],
@@ -1184,9 +1184,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
-      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
       "cpu": [
         "loong64"
       ],
@@ -1201,9 +1201,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
-      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
       "cpu": [
         "mips64el"
       ],
@@ -1218,9 +1218,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
-      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
       "cpu": [
         "ppc64"
       ],
@@ -1235,9 +1235,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
-      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
       "cpu": [
         "riscv64"
       ],
@@ -1252,9 +1252,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
-      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
       "cpu": [
         "s390x"
       ],
@@ -1269,9 +1269,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
-      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
       "cpu": [
         "x64"
       ],
@@ -1285,27 +1285,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
-      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
-      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
       "cpu": [
         "x64"
       ],
@@ -1320,9 +1303,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
-      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
       "cpu": [
         "arm64"
       ],
@@ -1337,9 +1320,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
-      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
       "cpu": [
         "x64"
       ],
@@ -1353,27 +1336,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
-      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
-      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
       "cpu": [
         "x64"
       ],
@@ -1388,9 +1354,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
-      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
       "cpu": [
         "arm64"
       ],
@@ -1405,9 +1371,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
-      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
       "cpu": [
         "ia32"
       ],
@@ -1422,9 +1388,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
-      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
       "cpu": [
         "x64"
       ],
@@ -4180,9 +4146,9 @@
       "optional": true
     },
     "node_modules/esbuild": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
-      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4193,32 +4159,30 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.2",
-        "@esbuild/android-arm": "0.28.2",
-        "@esbuild/android-arm64": "0.28.2",
-        "@esbuild/android-x64": "0.28.2",
-        "@esbuild/darwin-arm64": "0.28.2",
-        "@esbuild/darwin-x64": "0.28.2",
-        "@esbuild/freebsd-arm64": "0.28.2",
-        "@esbuild/freebsd-x64": "0.28.2",
-        "@esbuild/linux-arm": "0.28.2",
-        "@esbuild/linux-arm64": "0.28.2",
-        "@esbuild/linux-ia32": "0.28.2",
-        "@esbuild/linux-loong64": "0.28.2",
-        "@esbuild/linux-mips64el": "0.28.2",
-        "@esbuild/linux-ppc64": "0.28.2",
-        "@esbuild/linux-riscv64": "0.28.2",
-        "@esbuild/linux-s390x": "0.28.2",
-        "@esbuild/linux-x64": "0.28.2",
-        "@esbuild/netbsd-arm64": "0.28.2",
-        "@esbuild/netbsd-x64": "0.28.2",
-        "@esbuild/openbsd-arm64": "0.28.2",
-        "@esbuild/openbsd-x64": "0.28.2",
-        "@esbuild/openharmony-arm64": "0.28.2",
-        "@esbuild/sunos-x64": "0.28.2",
-        "@esbuild/win32-arm64": "0.28.2",
-        "@esbuild/win32-ia32": "0.28.2",
-        "@esbuild/win32-x64": "0.28.2"
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "make": "electron-forge make",
     "publish": "electron-forge publish",
     "test": "node --test \"test/*.test.js\"",
-    "lint": "echo \"No linting configured\""
+    "lint": "echo \"No linting configured\"",
+    "use:legacy-electron": "npm install --no-save electron@^32.3.3"
   },
   "keywords": [
     "writing",
@@ -87,7 +88,7 @@
     "@electron-forge/maker-squirrel": "^7.11.2",
     "@electron-forge/maker-zip": "^7.11.2",
     "electron": "^44.2.0",
-    "esbuild": "^0.28.2",
+    "esbuild": "^0.23.1",
     "jsdom": "^29.1.1"
   }
 }

--- a/src/components/controllers/platform-node.js
+++ b/src/components/controllers/platform-node.js
@@ -281,8 +281,18 @@ function createNodeBacking(deps){
 
   //process.platform/process.arch are plain Node globals, present with or without nodeIntegration -
   //nothing to inject, apart from the `platform` test seam described above.
+  //`electron` is the Electron this build was packaged against, or null anywhere Electron is not the
+  //host (the test harness, plain node). updates.js needs it to tell the two macOS lineages apart:
+  //the legacy mac build ships a pinned older Electron and follows its own release asset. It cannot
+  //be read on the renderer side - process.versions is not there with nodeIntegration off - and it
+  //is deliberately the packaged Electron rather than the host's OS version, because a legacy build
+  //runs perfectly well on a new mac and has to keep updating along the legacy track when it does.
   function getPlatform(){
-    return { platform: currentPlatform(), arch: process.arch };
+    return {
+      platform: currentPlatform(),
+      arch: process.arch,
+      electron: process.versions.electron || null
+    };
   }
 
   function currentPlatform(){

--- a/src/components/controllers/platform.js
+++ b/src/components/controllers/platform.js
@@ -154,7 +154,7 @@ var COMMANDS = {
   getAppPaths: { group: 'A', params: [],
     returns: '{ userData, home, temp, docs, app, downloads }',
     note: 'Convert first (Phase 2). It is sendSync at module load in render.js:4, so nothing else goes async cleanly while it stays that way.' },
-  getPlatform: { group: 'A', params: [], returns: '{ platform, arch }' },
+  getPlatform: { group: 'A', params: [], returns: '{ platform, arch, electron }' },
   getFileRequestedOnOpen: { group: 'A', params: [], returns: 'string | null' },
   setTheme: { group: 'A', params: ['mode'], returns: 'void' },
   showAppMenu: { group: 'A', params: [], returns: 'void' },

--- a/src/components/controllers/updates.js
+++ b/src/components/controllers/updates.js
@@ -61,6 +61,33 @@ function packageReleaseData(releaseData){
     return packagedData;
 }
 
+//The legacy mac build is a second, permanently-older lineage. Electron 44 needs macOS 13 Ventura,
+//so every mac between 10.15 Catalina and 12 Monterey gets its own asset, built from this same
+//source against a pinned Electron 32 (the last line that runs on Catalina). Both lineages ship
+//this same file, so a running build has to sort itself onto the right track.
+//
+//What identifies it is the Electron it was packaged against, not the host OS: the legacy build
+//runs fine on a new mac - under Rosetta on Apple Silicon, where process.arch reports x64 like any
+//other Intel build - and when it does it must keep following the legacy asset rather than jumping
+//to a mainline one its Electron predates.
+//
+//The legacy asset's name deliberately shares no substring with 'MacOS_Intel'. The find() below
+//takes the first name that merely *includes* binType, so calling it MacOS_Intel_Legacy would hand
+//it to modern Intel users - or hand them the mainline build on Catalina, where it cannot launch -
+//depending on nothing more than the order the GitHub API happens to list assets in. That is the
+//same collision release.yml already avoids by naming the Apple Silicon asset 'AppleSilicon'
+//rather than 'arm64'.
+var LEGACY_MACOS_ELECTRON_MAJOR = 32;
+
+function isLegacyMacBuild(electronVersion){
+    if(!electronVersion)
+        return false;
+
+    var major = parseInt(String(electronVersion).split('.')[0], 10);
+
+    return !isNaN(major) && major <= LEGACY_MACOS_ELECTRON_MAJOR;
+}
+
 function extractUpdateDownloadInfo(releaseData, platformInfo){
 
     var binType = 'unsupported';
@@ -76,8 +103,12 @@ function extractUpdateDownloadInfo(releaseData, platformInfo){
             binType = 'Windows_x64';
     }
     else if(platformInfo.platform == 'darwin'){
-        if(platformInfo.arch == 'x64')
-            binType = 'MacOS_Intel';
+        if(platformInfo.arch == 'x64'){
+            if(isLegacyMacBuild(platformInfo.electron))
+                binType = 'MacOS_Legacy';
+            else
+                binType = 'MacOS_Intel';
+        }
         else if(platformInfo.arch == 'arm64')
             binType = 'MacOS_AppleSilicon';
     }

--- a/test/platform.test.js
+++ b/test/platform.test.js
@@ -470,7 +470,23 @@ test('getAppPaths returns exactly the six documented fields, field by field', as
 test('getPlatform reports this process\'s own platform and arch', async function(){
   const platform = wrap(createNodeBacking({}));
 
-  assert.deepStrictEqual(await platform.getPlatform(), { platform: process.platform, arch: process.arch });
+  assert.deepStrictEqual(await platform.getPlatform(), {
+    platform: process.platform,
+    arch: process.arch,
+    electron: process.versions.electron || null
+  });
+});
+
+//The suite runs on plain node, where there is no process.versions.electron at all. That has to
+//arrive as null rather than a missing key: updates.js reads it across the ipc backing, and a key
+//whose value is undefined is not guaranteed to survive that trip, so the shape the renderer sees
+//would quietly differ from the shape this backing returns in-process.
+test('getPlatform reports a null electron version off Electron rather than omitting the field', async function(){
+  const platform = wrap(createNodeBacking({}));
+  const info = await platform.getPlatform();
+
+  assert.ok('electron' in info, 'electron must always be present as a key');
+  assert.strictEqual(info.electron, process.versions.electron || null);
 });
 
 test('getFileRequestedOnOpen returns whatever the backing was constructed with, or null', async function(){

--- a/test/updates.test.js
+++ b/test/updates.test.js
@@ -67,7 +67,8 @@ function releaseJson(tag, overrides){
       { name: 'warewoolf_' + v + '_arm64.deb', browser_download_url: 'https://example.com/' + v + '/arm64.deb' },
       { name: 'warewoolf_' + v + '_Windows_x64.zip', browser_download_url: 'https://example.com/' + v + '/win.zip' },
       { name: 'warewoolf_' + v + '_MacOS_Intel.zip', browser_download_url: 'https://example.com/' + v + '/mac-intel.zip' },
-      { name: 'warewoolf_' + v + '_MacOS_AppleSilicon.zip', browser_download_url: 'https://example.com/' + v + '/mac-arm.zip' }
+      { name: 'warewoolf_' + v + '_MacOS_AppleSilicon.zip', browser_download_url: 'https://example.com/' + v + '/mac-arm.zip' },
+      { name: 'warewoolf_' + v + '_MacOS_Legacy.zip', browser_download_url: 'https://example.com/' + v + '/mac-legacy.zip' }
     ]
   }, overrides));
 }
@@ -370,29 +371,111 @@ test('getUpdates regression: destroys the request once it times out', async func
   assert.ok(capturedReq.destroyedWith instanceof Error);
 });
 
+//`electron` is what the build was packaged against, and on darwin it decides which of the two mac
+//lineages the build follows. Leaving it off a row is itself a case worth covering: that is this
+//suite's own situation, plain node with no process.versions.electron, and it has to read as
+//mainline rather than legacy.
+function asPlatform(t, c){
+  const orig = {
+    platform: Object.getOwnPropertyDescriptor(process, 'platform'),
+    arch: Object.getOwnPropertyDescriptor(process, 'arch'),
+    electron: Object.getOwnPropertyDescriptor(process.versions, 'electron')
+  };
+  Object.defineProperty(process, 'platform', { value: c.platform, configurable: true });
+  Object.defineProperty(process, 'arch', { value: c.arch, configurable: true });
+  if(c.electron)
+    Object.defineProperty(process.versions, 'electron', { value: c.electron, configurable: true });
+  else
+    delete process.versions.electron;
+
+  t.after(function(){
+    Object.defineProperty(process, 'platform', orig.platform);
+    Object.defineProperty(process, 'arch', orig.arch);
+    if(orig.electron)
+      Object.defineProperty(process.versions, 'electron', orig.electron);
+    else
+      delete process.versions.electron;
+  });
+}
+
 [
   { platform: 'linux', arch: 'x64', expected: 'amd64' },
   { platform: 'linux', arch: 'arm64', expected: 'arm64' },
   { platform: 'win32', arch: 'x64', expected: 'Windows_x64' },
   { platform: 'darwin', arch: 'x64', expected: 'MacOS_Intel' },
-  { platform: 'darwin', arch: 'arm64', expected: 'MacOS_AppleSilicon' }
+  { platform: 'darwin', arch: 'arm64', expected: 'MacOS_AppleSilicon' },
+  { platform: 'darwin', arch: 'x64', electron: '44.2.0', expected: 'MacOS_Intel' },
+  { platform: 'darwin', arch: 'arm64', electron: '44.2.0', expected: 'MacOS_AppleSilicon' },
+  { platform: 'darwin', arch: 'x64', electron: '32.3.3', expected: 'MacOS_Legacy' },
+  //The boundary from both sides. 32 is the last line that runs on Catalina; 33 raised the floor to
+  //Big Sur and is therefore mainline.
+  { platform: 'darwin', arch: 'x64', electron: '32.0.0', expected: 'MacOS_Legacy' },
+  { platform: 'darwin', arch: 'x64', electron: '33.0.0', expected: 'MacOS_Intel' },
+  //A legacy build on an Apple Silicon mac runs under Rosetta, where process.arch reports x64 just
+  //as it does on real Intel hardware. It has to stay on the legacy track anyway: its Electron
+  //predates every mainline asset on offer.
+  { platform: 'darwin', arch: 'x64', electron: '32.3.3', rosetta: true, expected: 'MacOS_Legacy' }
 ].forEach(function(c){
-  test('getUpdates selects the ' + c.expected + ' binary on ' + c.platform + '/' + c.arch, async function(t){
+  const label = c.platform + '/' + c.arch + (c.electron ? '/electron ' + c.electron : '/no electron')
+    + (c.rosetta ? ' (Rosetta)' : '');
+
+  test('getUpdates selects the ' + c.expected + ' binary on ' + label, async function(t){
     mockReleaseResponse(t, { body: releaseJson('v2.0.0') });
-    const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-    const origArch = Object.getOwnPropertyDescriptor(process, 'arch');
-    Object.defineProperty(process, 'platform', { value: c.platform, configurable: true });
-    Object.defineProperty(process, 'arch', { value: c.arch, configurable: true });
-    t.after(function(){
-      Object.defineProperty(process, 'platform', origPlatform);
-      Object.defineProperty(process, 'arch', origArch);
-    });
+    asPlatform(t, c);
+    const { getUpdates } = freshUpdates();
+
+    //Whole-name equality rather than includes(): a substring assertion here is the same weakness
+    //that makes the production find() collide, and would pass on the wrong asset.
+    const ext = c.platform == 'linux' ? '.deb' : '.zip';
+    const latest = await new Promise(function(resolve){ getUpdates('1.0.0', resolve); });
+    assert.ok(latest.downloadInfo, 'expected a matching binary to be selected');
+    assert.strictEqual(latest.downloadInfo.name, 'warewoolf_2.0.0_' + c.expected + ext);
+  });
+});
+
+//Regression, and the reason the legacy asset is not named MacOS_Intel_Legacy.
+//extractUpdateDownloadInfo picks with find(), which takes the first name that merely *includes*
+//binType - so a legacy name carrying the mainline substring would be handed out on whichever
+//ordering the GitHub API happened to return that day. The names are checked here for the overlap
+//that would make ordering matter at all, and the two lineages are checked below against an
+//ordering deliberately chosen to break a name that had it.
+test('the legacy and mainline mac asset names cannot match each other by substring', function(){
+  assert.ok(!'warewoolf_2.0.0_MacOS_Legacy.zip'.includes('MacOS_Intel'));
+  assert.ok(!'warewoolf_2.0.0_MacOS_Intel.zip'.includes('MacOS_Legacy'));
+  assert.ok(!'warewoolf_2.0.0_MacOS_Legacy.zip'.includes('MacOS_AppleSilicon'));
+  assert.ok(!'warewoolf_2.0.0_MacOS_Legacy.zip'.includes('arm64'));
+});
+
+[
+  { electron: '32.3.3', expected: 'warewoolf_2.0.0_MacOS_Legacy.zip', other: 'the mainline build it cannot launch' },
+  { electron: '44.2.0', expected: 'warewoolf_2.0.0_MacOS_Intel.zip', other: 'a silent downgrade to the legacy build' }
+].forEach(function(c){
+  test('an Electron ' + c.electron + ' mac build is never offered ' + c.other + ', whatever order the assets are listed in', async function(t){
+    //Legacy listed first, the ordering that would break a substring-overlapping name.
+    mockReleaseResponse(t, { body: releaseJson('v2.0.0', { assets: [
+      { name: 'warewoolf_2.0.0_MacOS_Legacy.zip', browser_download_url: 'https://example.com/2.0.0/mac-legacy.zip' },
+      { name: 'warewoolf_2.0.0_MacOS_Intel.zip', browser_download_url: 'https://example.com/2.0.0/mac-intel.zip' }
+    ] }) });
+    asPlatform(t, { platform: 'darwin', arch: 'x64', electron: c.electron });
     const { getUpdates } = freshUpdates();
 
     const latest = await new Promise(function(resolve){ getUpdates('1.0.0', resolve); });
-    assert.ok(latest.downloadInfo, 'expected a matching binary to be selected');
-    assert.ok(latest.downloadInfo.name.includes(c.expected));
+    assert.strictEqual(latest.downloadInfo.name, c.expected);
   });
+});
+
+//A legacy build looking at a release that predates the legacy lineage - every release before this
+//one - finds nothing, rather than falling back to a mainline asset that cannot launch on its OS.
+test('a legacy mac build finds no binary in a release that has no legacy asset', async function(t){
+  mockReleaseResponse(t, { body: releaseJson('v2.0.0', { assets: [
+    { name: 'warewoolf_2.0.0_MacOS_Intel.zip', browser_download_url: 'https://example.com/2.0.0/mac-intel.zip' }
+  ] }) });
+  asPlatform(t, { platform: 'darwin', arch: 'x64', electron: '32.3.3' });
+  const { getUpdates } = freshUpdates();
+
+  const latest = await new Promise(function(resolve){ getUpdates('1.0.0', resolve); });
+  assert.ok(latest, 'an update is still announced');
+  assert.strictEqual(latest.downloadInfo, undefined);
 });
 
 test('getUpdates regression: leaves downloadInfo undefined instead of throwing on an unsupported platform/arch combo', async function(t){


### PR DESCRIPTION
Electron 44 requires macOS 13 Ventura, which leaves every Mac from 10.15
Catalina through 12 Monterey with no build at all — a real gap for the
writerdeck audience, who are often on exactly that hardware.

This adds a second macOS asset, `warewoolf_<version>_MacOS_Legacy.dmg`,
built from this same source against a pinned Electron 32 (the last line
that runs on Catalina), produced automatically on every tagged release.

## No old Mac needed to build it

electron-forge only downloads a prebuilt Electron for the target and copies
the app into it, and this project has no native modules — so the minimum-OS
floor comes from the pinned Electron, not from the runner. An ordinary
`macos-latest` runner produces it.

The release workflow gets a third macOS matrix entry that swaps Electron in
after `npm ci` with `--no-save`, then verifies the built app's
`LSMinimumSystemVersion` is `10.x` rather than trusting that the pin took —
the same reasoning as the existing deb-compression check. The upload step
now keys its artifact name off `matrix.label`; both mac x64 entries would
otherwise upload under one name and clobber each other.

## Updater routing

The updater picks assets with a `find()` over `includes()`, so the new name
shares no substring with `MacOS_Intel`. An overlapping name (`MacOS_Intel_Legacy`)
would be handed out on whatever order the GitHub API listed assets in —
offering modern Intel users the legacy build, or offering Catalina users a
build that cannot launch. Same collision `release.yml` already avoids by
naming the Apple Silicon asset `AppleSilicon` rather than `arm64`.

Which lineage a build follows is decided by the Electron it was packaged
against, not the host OS: a legacy build runs fine on a new Mac, including
under Rosetta where `process.arch` reports x64, and must keep following the
legacy asset when it does. `getPlatform()` carries that version across the
bridge, since the renderer can't read `process.versions` with nodeIntegration
off.

## Also

`esbuild` held at 0.23.x — 0.24.0 is built with Go 1.23, which dropped macOS
10.15, so anything newer fails to install on Catalina with a dyld symbol
error. Plus `npm run use:legacy-electron` for local work on an old Mac. Both
are concessions to *developing* on an old Mac, not to shipping for one.

## Testing

1318 pass, 0 fail (1306 before). Twelve new tests: both lineages against a
deliberately hostile asset ordering, the Electron 32/33 boundary from both
sides, Rosetta, and the substring-overlap check itself. The existing platform
matrix is tightened from `includes()` to whole-name equality — a substring
assertion there is the same weakness that makes the production `find()`
collide, and would pass on the wrong asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)